### PR TITLE
optional stable_replicas application.json field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('LICENSE') as f:
 
 setup(
     name='kubelib',
-    version='0.3.9',
+    version='0.3.10',
     description='Utility wrapper around Kubectl',
     long_description=readme,
     author='Jason Kane',


### PR DESCRIPTION
If we have replica # changes from outside the deployment pipeline (generally autoscalers) a subsequent deployment will reset the service to whatever # is in github.  This could cause a catastrophic decline in our ability to service traffic and be easily mis-diagnosed as a code problem with the release.

stable_replicas overrides whatever replica count is in your yaml with the current number of replicas in the deployment context for that pod.